### PR TITLE
remove outdated edge version from travis config

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,8 +9,6 @@ script:
 
 # Deploy to GitHub pages
 deploy:
-  edge:
-    branch: v1.8.47
   provider: pages
   skip_cleanup: true
   local_dir: public


### PR DESCRIPTION
I believe this edge version was set at a time when it was necessary for the build to succeed, perhaps just using whatever later version Travis defaults to will allow for dependencies to build