### PR TITLE
Add some custom CSS to improve readability of blog posts

### DIFF
--- a/config.toml
+++ b/config.toml
@@ -61,7 +61,7 @@ canonifyURLs = true
   # files by adding the value, "default".
   # customCSS            = ["default", "/path/to/file"]
   # customJS             = ["default", "/path/to/file"]
-  customCSS            = ["default"]
+  customCSS            = ["default", "/css/custom.css"]
   customJS             = ["default"]
 
   # options for highlight.js (version, additional languages, and theme)

--- a/static/css/custom.css
+++ b/static/css/custom.css
@@ -1,0 +1,6 @@
+.post #content {
+  max-width: 750px;
+  margin: 0 auto;
+  font-size: 18px;
+  line-height: 25px;
+}


### PR DESCRIPTION
- Max width + centering margins so the eye can stay centered
- Larger font size and slightly narrower line height, so the eye can stay in place as it reads

### Before
![image](https://user-images.githubusercontent.com/10286362/52432316-0014e400-2abf-11e9-985c-354af7e299ca.png)

### After
![image](https://user-images.githubusercontent.com/10286362/52432397-2d619200-2abf-11e9-944b-e5a50e87a458.png)
